### PR TITLE
Set masking to false for dc action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,10 +24,11 @@ jobs:
 
       - name: create data container
         id: create-container
-        uses: red-gate/create-spawn-data-container/@v1
+        uses: red-gate/create-spawn-data-container/@v1.1
         with:
           dataImage: ${{ env.SPAWNDATAIMAGE }}
           lifetime: '15m'
+          useMasking: 'false'
         env:
           SPAWNCTL_ACCESS_TOKEN: ${{ secrets.SPAWNCTL_ACCESS_TOKEN }}
 


### PR DESCRIPTION
GitHub Actions won't output values when they believe it is a secret. 

Use the new `useMasking` option and set to false so the data container connection details aren't masked and can be passed between jobs as outputs